### PR TITLE
Update images digests

### DIFF
--- a/giropops-senhas/Dockerfile
+++ b/giropops-senhas/Dockerfile
@@ -1,5 +1,5 @@
 # Etapa de construção
-FROM cgr.dev/chainguard/python:latest-dev@sha256:03b630216f9fa76a0dedc4e7f6f40bea22b2fd56e32a625227d8135e9256c2da as build
+FROM cgr.dev/chainguard/python:latest-dev@sha256:63f5250460eb0493fa7a676acd2405b1a8ae7a68c2fff20b477418daed6442b0 as build
 
 # Definir o diretório de trabalho
 WORKDIR /app
@@ -11,7 +11,7 @@ COPY . /app
 RUN pip install -r requirements.txt --user
 
 # Etapa final
-FROM cgr.dev/chainguard/python:latest@sha256:11857e623e3869769d46f875533358a4658c6e08263cc9dafc32711a4a36c8c7
+FROM cgr.dev/chainguard/python:latest@sha256:99ee1559c4632e06f293a2f03a2677e6bff371d37b4de6e21322715cb0697055
 
 # Definir o diretório de trabalho
 WORKDIR /app


### PR DESCRIPTION
Update images digests

```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Atualização do Dockerfile para referenciar novas imagens base com hashes SHA256 atualizados para as versões `latest-dev` e `latest` da imagem `cgr.dev/chainguard/python`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->