### PR TITLE
Adiciona hashes de integridade ao requirements.txt para maior segurança

### DIFF
--- a/chainguard/requirements.txt
+++ b/chainguard/requirements.txt
@@ -1,4 +1,8 @@
-Flask==3.1.1
-redis==6.1.0
-prometheus-client==0.21.1
-Werkzeug==3.1.3
+Flask==3.1.1 \
+    --hash=sha256:07aae2bb5eaf77993ef57e357491839f5fd9f4dc281593a81a9e4d79a24f295c
+redis==6.1.0 \
+    --hash=sha256:3b72622f3d3a89df2a6041e82acd896b0e67d9f54e9bcd906d091d23ba5219f6
+prometheus-client==0.21.1 \
+    --hash=sha256:594b45c410d6f4f8888940fe80b5cc2521b305a1fafe1c58609ef715a001f301
+Werkzeug==3.1.3 \
+    --hash=sha256:54b78bf3716d19a65be4fceccc0d1d7b89e608834989dfae50ea87564639213e


### PR DESCRIPTION
## Adiciona hashes de integridade ao requirements.txt

Este PR adiciona os hashes SHA256 das versões dos pacotes Python no arquivo requirements.txt, utilizando o parâmetro `--hash` para cada dependência.  
Com isso, a instalação das dependências fica mais segura e reprodutível, protegendo contra ataques de supply chain e alterações inesperadas nos pacotes.

### Mudanças principais:
- Adiciona os hashes de integridade para Flask, redis, prometheus-client e Werkzeug no requirements.txt.

### Benefícios:
- Garante que apenas os arquivos exatos das dependências aprovadas serão instalados.
- Melhora a segurança do pipeline e da aplicação.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Adicionados hashes SHA-256 explícitos para cada pacote Python listado, aumentando a segurança na instalação dos pacotes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->