### PR TITLE
 Integridade ao processo de instalação do Docker no script tools.sh

### DIFF
--- a/scripts/tools.sh
+++ b/scripts/tools.sh
@@ -1,20 +1,22 @@
 #!/bin/bash
+set -euo pipefail
 
 # Instalando o Docker
 
-# Baixando o script de instalação do Docker
-curl -fsSL https://get.docker.com -o /tmp/get-docker.sh
+# Baixando o script de instalação do Docker de forma segura
+TMP_DOCKER_SCRIPT=$(mktemp)
+curl -fsSL https://get.docker.com -o "$TMP_DOCKER_SCRIPT"
 
 # Verificando o hash SHA256 do script (atualize o hash se necessário)
 EXPECTED_HASH="0158433a384a7ef6d60b6d58e556f4587dc9e1ee9768dae8958266ffb4f84f6f"
-ACTUAL_HASH=$(sha256sum /tmp/get-docker.sh | awk '{print $1}')
+ACTUAL_HASH=$(sha256sum "$TMP_DOCKER_SCRIPT" | awk '{print $1}')
 
 if [ "$EXPECTED_HASH" != "$ACTUAL_HASH" ]; then
   echo "[ERRO] O hash do script get-docker.sh não confere! Abortando instalação por segurança."
   exit 1
 fi
 
-bash /tmp/get-docker.sh
+bash "$TMP_DOCKER_SCRIPT"
 curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
 sudo chmod +x /usr/local/bin/docker-compose
 sudo ln -s /usr/local/bin/docker-compose /usr/bin/docker-compose 

--- a/scripts/tools.sh
+++ b/scripts/tools.sh
@@ -12,7 +12,8 @@ EXPECTED_HASH="0158433a384a7ef6d60b6d58e556f4587dc9e1ee9768dae8958266ffb4f84f6f"
 ACTUAL_HASH=$(sha256sum "$TMP_DOCKER_SCRIPT" | awk '{print $1}')
 
 if [ "$EXPECTED_HASH" != "$ACTUAL_HASH" ]; then
-  echo "[ERRO] O hash do script get-docker.sh não confere! Abortando instalação por segurança."
+  echo "[ERRO] O hash do script get-docker.sh não confere! Abortando instalação por segurança." >&2
+  rm -f "$TMP_DOCKER_SCRIPT"
   exit 1
 fi
 

--- a/scripts/tools.sh
+++ b/scripts/tools.sh
@@ -2,7 +2,19 @@
 
 # Instalando o Docker
 
-curl https://get.docker.com | bash
+# Baixando o script de instalação do Docker
+curl -fsSL https://get.docker.com -o /tmp/get-docker.sh
+
+# Verificando o hash SHA256 do script (atualize o hash se necessário)
+EXPECTED_HASH="0158433a384a7ef6d60b6d58e556f4587dc9e1ee9768dae8958266ffb4f84f6f"
+ACTUAL_HASH=$(sha256sum /tmp/get-docker.sh | awk '{print $1}')
+
+if [ "$EXPECTED_HASH" != "$ACTUAL_HASH" ]; then
+  echo "[ERRO] O hash do script get-docker.sh não confere! Abortando instalação por segurança."
+  exit 1
+fi
+
+bash /tmp/get-docker.sh
 curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
 sudo chmod +x /usr/local/bin/docker-compose
 sudo ln -s /usr/local/bin/docker-compose /usr/bin/docker-compose 


### PR DESCRIPTION
Este pull request adiciona uma verificação de integridade ao processo de instalação do Docker no script tools.sh. Agora, o script baixa o instalador do Docker (`get.docker.sh`), verifica o hash SHA256 do arquivo baixado e só executa o instalador caso o hash corresponda ao valor esperado. Isso aumenta a segurança do processo de instalação, prevenindo a execução de scripts potencialmente comprometidos.

### Mudanças realizadas

- Substituição do comando `curl https://get.docker.com | bash` por:
  - Download do script para get-docker.sh
  - Verificação do hash SHA256 do script baixado
  - Execução do script apenas se o hash for válido

### Motivação

Esta alteração resolve o alerta de segurança referente a dependências não pinadas (un-pinned dependencies), conforme apontado pelo GitHub Code Scanning/Scorecard. Pinando o hash do script, mitigamos riscos de ataques de supply chain e aumentamos a confiabilidade do processo de build.

### Como testar

1. Execute o script tools.sh.
2. O script deve baixar o instalador do Docker, verificar o hash e só executar se o hash for o esperado.
3. Caso o hash não corresponda, a instalação será abortada com uma mensagem de erro.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Melhorada a segurança do processo de instalação do Docker, incluindo verificação de integridade do script antes da execução.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->